### PR TITLE
Fix style issues and lines

### DIFF
--- a/parser.py
+++ b/parser.py
@@ -2,6 +2,7 @@
 
 from html.parser import HTMLParser
 
+
 class BookmarkHTMLParser(HTMLParser):
     def __init__(self):
         super().__init__()
@@ -44,6 +45,7 @@ class BookmarkHTMLParser(HTMLParser):
     def handle_data(self, data):
         if self.current_tag in {"h3", "a"}:
             self.current_data += data
+
 
 def parse_bookmarks_html(file_path):
     """Liest eine HTML-Datei ein und gibt eine Liste von Lesezeichen zurück."""

--- a/sync.py
+++ b/sync.py
@@ -32,7 +32,8 @@ def tree_to_html(tree, indent=0):
         if key == "_bookmarks":
             for bm in value:
                 line = (
-                    f'{indent_str}<DT><A HREF="{bm["url"]}" ADD_DATE="{bm["add_date"]}">{bm["title"]}</A>'
+                    f'{indent_str}<DT><A HREF="{bm["url"]}" '
+                    f'ADD_DATE="{bm["add_date"]}">{bm["title"]}</A>'
                 )
                 lines.append(line)
         else:
@@ -47,7 +48,10 @@ def export_bookmarks(bookmarks, output_file):
     tree = build_tree(bookmarks)
     with open(output_file, "w", encoding="utf-8") as f:
         f.write("<!DOCTYPE NETSCAPE-Bookmark-file-1>\n")
-        f.write('<META HTTP-EQUIV="Content-Type" CONTENT="text/html; charset=UTF-8">\n')
+        f.write(
+            '<META HTTP-EQUIV="Content-Type" '
+            'CONTENT="text/html; charset=UTF-8">\n'
+        )
         f.write("<TITLE>Bookmarks</TITLE>\n")
         f.write("<H1>Bookmarks</H1>\n\n")
         f.write("<DL><p>\n")


### PR DESCRIPTION
## Summary
- format parser and sync modules
- split long lines for flake8 compliance

## Testing
- `flake8`
- `python -m py_compile parser.py sync.py`
- `python sync.py sample1.html sample2.html merged.html`

------
https://chatgpt.com/codex/tasks/task_e_684acd0d59c48333b7d2ef730c2f9852